### PR TITLE
Add momentum indicator

### DIFF
--- a/part 3/botindicators.py
+++ b/part 3/botindicators.py
@@ -5,3 +5,7 @@ class BotIndicators(object):
 	def movingAverage(self, dataPoints, period):
 		if (len(dataPoints) > 1):
 			return sum(dataPoints[-period:]) / float(len(dataPoints[-period:]))
+		
+	def momentum (self, dataPoints, period=14):
+		if (len(dataPoints) > period -1):
+			return dataPoints[-1] * 100 / dataPoints[-period]


### PR DESCRIPTION
There are basically two ways to use the Momentum indicator:

As a trend-following indicator similar to the Moving Average Convergence/Divergence (MACD) indicator. In this case, a signal to buy occurs if the Momentum indicator makes up a trough and starts rising; a signal to sell occurs when it reaches a peak and turns down. You may want to plot a short-term moving average of the indicator to determine when it is bottoming or peaking. Extremely high or low values of Momentum imply a continuation of the current trend. Thus if the indicator reaches extremely high values and then turns down, the further price growth should be expected. In any case, a position should be opened or closed only after prices confirm the signal generated by the indicator.

As a leading indicator. This method assumes that the final phase of an up-trend is usually accompanied by a rapid price increase (when everyone expects prices to go higher) and that the end of Bears' market is characterised by rapid price declines (when everyone wants to get out). This is often the case, but it is also a broad generalisation. When market approaches a peak there is a sharp leap of the Momentum indicator. After that, it starts to fall while prices keep on growing or move horizontally. Analogous to that, at the market bottom Momentum sharply falls and then turns up long before prices start growing. Both of these situations result in divergences between the indicator and prices. 


Calculation
Momentum is calculated as a ratio of today’s price to the price n periods ago:

MOMENTUM = CLOSE (i) / CLOSE (i - n) * 100

Where:
CLOSE (i) — the close price of the current bar;
CLOSE (i - n) — the close price n bars ago.